### PR TITLE
fix: command menu overflow display

### DIFF
--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -15,7 +15,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      "flex size-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      "flex size-full flex-col rounded-md bg-popover text-popover-foreground",
       className,
     )}
     {...props}


### PR DESCRIPTION
Clicking on the command menu on the home page makes contents blurry. This does not happen if the menu height exceeds the items' height.